### PR TITLE
PLACES-316 Update GET access-code/valid to POST access-code/valid

### DIFF
--- a/app/api/upload/router.js
+++ b/app/api/upload/router.js
@@ -1,7 +1,7 @@
 const server = require('../../../src/server');
 const controller = require('./controller');
 
-server.get(
+server.post(
   '/access-code/valid',
   server.wrapAsync(
     async (req, res) => await controller.checkValid(req, res),

--- a/test/integration/accessCode.test.js
+++ b/test/integration/accessCode.test.js
@@ -10,7 +10,7 @@ const accessCodes = require('../../db/models/accessCodes');
 
 chai.use(chaiHttp);
 
-describe('GET /access-code/valid', () => {
+describe('POST /access-code/valid', () => {
   let currentAccessCode;
 
   beforeEach(async () => {
@@ -21,7 +21,7 @@ describe('GET /access-code/valid', () => {
   it('should fail when request is malformed', async () => {
     let result = await chai
       .request(server.app)
-      .get('/access-code/valid')
+      .post('/access-code/valid')
       .send();
     result.should.have.status(400);
   });
@@ -29,7 +29,7 @@ describe('GET /access-code/valid', () => {
   it('should succeed when code is valid', async () => {
     const result = await chai
       .request(server.app)
-      .get('/access-code/valid')
+      .post('/access-code/valid')
       .send({
         accessCode: currentAccessCode.value,
       });
@@ -43,7 +43,7 @@ describe('GET /access-code/valid', () => {
 
     const result = await chai
       .request(server.app)
-      .get('/access-code/valid')
+      .post('/access-code/valid')
       .send({
         accessCode: currentAccessCode.value,
       });
@@ -55,7 +55,7 @@ describe('GET /access-code/valid', () => {
   it('should succeed when code does not exist', async () => {
     const result = await chai
       .request(server.app)
-      .get('/access-code/valid')
+      .post('/access-code/valid')
       .send({
         accessCode: "fake_code",
       });


### PR DESCRIPTION
Body params on GET requests are incompatible with React Native fetch requests. We can't use query params or route params because of the following:

Using query params was inconsistent with the other requests

Using a route param would leave logs in the server

So we should update this endpoint to be `POST` instead of `GET`