### PR TITLE
Reverting hashing

### DIFF
--- a/app/lib/geoHash.js
+++ b/app/lib/geoHash.js
@@ -1,0 +1,63 @@
+const geohash = require('ngeohash');
+const crypto = require('crypto');
+const Promise = require('bluebird');
+
+/*
+
+We use a scrypt hash with the following parameters:
+
+- A “cost” (N) that is to be determined.  For initial implemention we 
+  use 2^12 = 16384.  For improved security we expect to move to 
+  2^16,. 2^17 or 2^18 for production, but the exact value still needs 
+  to be determined.
+- A block size (r) of 8 - this is the default.
+- Parallelization (p) of 1 - this is the default.
+- A keylen (output) of 8 bytes = 16 hex digits.
+
+*/
+
+/**
+ * Encrypt location into a Hash
+ *
+ * @method encrypt
+ * @param {Object} location
+ * @param {String} salt
+ * @param {Boolean} debug
+ * @return {String}
+ */
+
+const encrypt = async (location, salt = 'salt') => {
+  const roundDownTo = roundTo => x => Math.floor(x / roundTo) * roundTo;
+  const roundDownTo5Minutes = roundDownTo(1000 * 60 * 5);
+  const roundedTime = roundDownTo5Minutes(new Date(location.time));
+  const hash = geohash.encode(location.latitude, location.longitude, 8); // precision of 8
+  const secret = `${hash}${roundedTime}`;
+
+  const options = {
+    N: 4096, // Only option that we might want to change.
+  };
+
+  const derivedKey = await Promise.fromCallback(cb =>
+    crypto.scrypt(secret, salt, 8, options, cb),
+  );
+  if (derivedKey) {
+    const encodedString = derivedKey.toString('hex');
+    return { hash, secret, encodedString };
+  }
+};
+
+/**
+ * Add Product to order
+ *
+ * @method decrypt
+ * @param {String} hash
+ * @return {Object}
+ */
+const decryptHash = hash => {
+  return geohash.decode(hash);
+};
+
+module.exports = {
+  encrypt,
+  decryptHash,
+};

--- a/db/migrations/20200630070951_revert_hashing.js
+++ b/db/migrations/20200630070951_revert_hashing.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('points', table => {
+    table.string('hash');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('points', table => {
+    table.dropColumn('hash');
+  });
+};

--- a/db/models/points.js
+++ b/db/models/points.js
@@ -1,6 +1,7 @@
 const BaseService = require('../common/service.js');
 const knex = require('../knex.js');
 const knexPostgis = require("knex-postgis");
+const geoHash = require('../../app/lib/geoHash');
 
 const st = knexPostgis(knex);
 
@@ -13,18 +14,23 @@ class Service extends BaseService {
 
     const pointRecords = [];
 
+    let record;
     for(let point of points) {
-      const record = {
-        access_code_id: accessCode.id,
-        upload_id: uploadId,
-        time: new Date(point.time), // Assumes time in epoch milliseconds
-        coordinates: st.setSRID(
-          st.makePoint(point.longitude, point.latitude),
-          4326
-        ),
-      };
+      const hash = await geoHash.encrypt(point);
 
-      pointRecords.push(record);
+      if (hash) {
+        record = {
+          access_code_id: accessCode.id,
+          upload_id: uploadId,
+          time: new Date(point.time), // Assumes time in epoch milliseconds
+          coordinates: st.setSRID(
+            st.makePoint(point.longitude, point.latitude),
+            4326
+          ),
+          hash: hash.encodedString
+        };
+        pointRecords.push(record);
+      }
     }
 
     return this.create(pointRecords);

--- a/test/integration/upload.test.js
+++ b/test/integration/upload.test.js
@@ -16,6 +16,7 @@ describe('POST /upload', () => {
     longitude: 14.91328448,
     latitude: 41.24060321,
     time: 1589117739000,
+    hash: "87e916850d4def3c",
   }];
 
   let currentAccessCode;
@@ -90,6 +91,7 @@ describe('POST /upload', () => {
         accessCode: currentAccessCode.value,
         concernPoints: uploadPoints,
       });
+      
     result.should.have.status(201);
     chai.should().exist(result.body.uploadId);
 

--- a/test/unit/geoHash.test.js
+++ b/test/unit/geoHash.test.js
@@ -1,0 +1,16 @@
+process.env.NODE_ENV = 'test';
+
+const expect = require('chai').expect;
+const geoHash = require('../../app/lib/geoHash');
+
+describe('Geo Hash', () => {
+  it('should return a properly formatted hash', async () => {
+    const location = {
+      longitude: 14.91328448,
+      latitude: 41.24060321,
+      time: 1589117939000,
+    };
+    const hash = await geoHash.encrypt(location, 'salt', true);
+    expect(hash.encodedString).to.be.equal('a2dcd196d350fda7');
+  });
+});


### PR DESCRIPTION
With the new ingest lib, we are going from discreet to duration only coming out of the translation lib to the front end.  Therefore, we can go ahead and do the hashing as it is uploaded, and then just transfer it to the private db.